### PR TITLE
feat: 리뷰 작성 보조 - 사용자 입력 감지 프로세스 추가

### DIFF
--- a/src/components/ReviewAssistant/index.tsx
+++ b/src/components/ReviewAssistant/index.tsx
@@ -6,12 +6,10 @@ import { ReactComponent as AIBot } from '@/assets/icons/aibot.svg';
 import { Row } from '@/ui/flex/flex';
 import { ReactComponent as Dot } from '@/assets/icons/dot.svg';
 import { Margin } from '@/ui/margin/margin';
+import { CommentType } from '@/types/Comments';
 
 interface Props {
-  comments: {
-    title: string;
-    content: string;
-  }[];
+  comments: CommentType[];
 }
 
 export default function ReviewAssistant(props: Props) {
@@ -26,7 +24,7 @@ export default function ReviewAssistant(props: Props) {
         </Fonts.caption>
       </AIBox>
       {comments.map((comment, index) => (
-        <Comment key={index} title={comment.title} content={comment.content} />
+        <Comment key={index} sort={comment.sort} content={comment.content} />
       ))}
     </Container>
   );
@@ -49,9 +47,12 @@ const Dots = () => {
   );
 };
 
-const Comment = ({ title, content }: { title: string; content: string }) => {
+const Comment = ({ sort, content }: { sort: number; content: string }) => {
+  let title;
+  if (sort == 1) title = '주제 추천';
+  if (sort == 2) title = '이 문장을 쓰려고 하셨나요?';
   return (
-    <CommentBox>
+    <CommentBox sort={sort}>
       <Row margin="0 0 6px 0">
         <AIBot style={{ width: 30 }} />
         <Fonts.body3 weight={500} margin="0 0 0 5px">
@@ -79,6 +80,7 @@ const AIBox = styled.div`
   justify-content: center;
   align-items: center;
   height: 30px;
+  padding: 0 10px;
   border-radius: 5px;
   background-color: ${colors.gray06};
   margin-bottom: 10px;
@@ -94,10 +96,14 @@ const BoxFadeIn = keyframes`
   }
 `;
 
-const CommentBox = styled.div`
+const CommentBox = styled.div<{ sort: number }>`
   display: flex;
   flex-direction: column;
-  border: 1px solid ${colors.gray06};
+  border-color: ${(props) =>
+    props.sort == 1 ? colors.gray06 : colors.primary};
+  border-width: ${(props) => (props.sort == 1 ? 1 : 2)}px;
+  border-radius: 5px;
+  border-style: solid;
   border-radius: 5px;
   padding: 16px 20px;
   margin-top: 10px;

--- a/src/components/ReviewAssistant/index.tsx
+++ b/src/components/ReviewAssistant/index.tsx
@@ -7,14 +7,15 @@ import { Row } from '@/ui/flex/flex';
 import { ReactComponent as Dot } from '@/assets/icons/dot.svg';
 import { Margin } from '@/ui/margin/margin';
 
-export default function ReviewAssistant() {
-  const [comments, setComments] = useState([
-    {
-      title: '리뷰 작성',
-      content:
-        '호텔 이용 중 불편한 점이 있으셨군요! 해당 상황에 대한 호텔의 조치는 어땠나요?',
-    },
-  ]);
+interface Props {
+  comments: {
+    title: string;
+    content: string;
+  }[];
+}
+
+export default function ReviewAssistant(props: Props) {
+  const { comments } = props;
 
   return (
     <Container>

--- a/src/components/ReviewEditor/index.tsx
+++ b/src/components/ReviewEditor/index.tsx
@@ -5,8 +5,16 @@ import ReviewRating from './ReviewRating';
 import FileInput from './FileInput';
 import { colors } from '@/utils/GlobalStyles';
 import useInputTimeout from '@/hooks/useInputTimeout';
+import { Comment } from '@/types/Comments';
 
-export default function ReviewEditor() {
+interface Props {
+  comments: Comment[];
+  setComments: React.Dispatch<React.SetStateAction<Comment[]>>;
+}
+
+export default function ReviewEditor(props: Props) {
+  const { comments, setComments } = props;
+
   const [text, setText] = useState<string>('');
   const [rating, setRating] = useState<number>(0);
   const [images, setImages] = useState<Array<string>>([]);
@@ -24,6 +32,14 @@ export default function ReviewEditor() {
   // 1초간 입력이 없을 경우 실행
   useInputTimeout(1000, () => {
     console.log('timeout');
+    setComments([
+      ...comments,
+      {
+        title: '리뷰 작성',
+        content:
+          '호텔 이용 중 불편한 점이 있으셨군요! 해당 상황에 대한 호텔의 조치는 어땠나요?',
+      },
+    ]);
   });
 
   return (

--- a/src/components/ReviewEditor/index.tsx
+++ b/src/components/ReviewEditor/index.tsx
@@ -5,11 +5,11 @@ import ReviewRating from './ReviewRating';
 import FileInput from './FileInput';
 import { colors } from '@/utils/GlobalStyles';
 import useInputTimeout from '@/hooks/useInputTimeout';
-import { Comment } from '@/types/Comments';
+import { CommentType } from '@/types/Comments';
 
 interface Props {
-  comments: Comment[];
-  setComments: React.Dispatch<React.SetStateAction<Comment[]>>;
+  comments: CommentType[];
+  setComments: React.Dispatch<React.SetStateAction<CommentType[]>>;
 }
 
 export default function ReviewEditor(props: Props) {
@@ -18,6 +18,19 @@ export default function ReviewEditor(props: Props) {
   const [text, setText] = useState<string>('');
   const [rating, setRating] = useState<number>(0);
   const [images, setImages] = useState<Array<string>>([]);
+
+  const CommentList = [
+    {
+      sort: 1,
+      content:
+        '호텔 이용 중 불편한 점이 있으셨군요! 해당 상황에 대한 호텔의 조치는 어땠나요?',
+    },
+    {
+      sort: 2,
+      content:
+        '그래도 다행히 프론트에 건의 했더니, 침구를 새걸로 교체해주셨습니다.',
+    },
+  ];
 
   const onChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setText(e.target.value);
@@ -29,17 +42,12 @@ export default function ReviewEditor(props: Props) {
     console.log(images);
   };
 
+  const [count, setCount] = useState(0);
   // 1초간 입력이 없을 경우 실행
-  useInputTimeout(1000, () => {
+  useInputTimeout(2000, () => {
     console.log('timeout');
-    setComments([
-      ...comments,
-      {
-        title: '리뷰 작성',
-        content:
-          '호텔 이용 중 불편한 점이 있으셨군요! 해당 상황에 대한 호텔의 조치는 어땠나요?',
-      },
-    ]);
+    setComments([...comments, CommentList[count]]);
+    setCount(1);
   });
 
   return (

--- a/src/components/ReviewEditor/index.tsx
+++ b/src/components/ReviewEditor/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import ReviewRating from './ReviewRating';
 import FileInput from './FileInput';
 import { colors } from '@/utils/GlobalStyles';
+import useInputTimeout from '@/hooks/useInputTimeout';
 
 export default function ReviewEditor() {
   const [text, setText] = useState<string>('');
@@ -19,6 +20,11 @@ export default function ReviewEditor() {
     console.log(rating + '점, ' + text);
     console.log(images);
   };
+
+  // 1초간 입력이 없을 경우 실행
+  useInputTimeout(1000, () => {
+    console.log('timeout');
+  });
 
   return (
     <Container>

--- a/src/hooks/useInputTimeout.tsx
+++ b/src/hooks/useInputTimeout.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+
+export default function useInputTimeout(timeout: number, callback: () => void) {
+  const [lastTime, setLastTime] = useState<number | null>(null);
+
+  const resetFunction = () => {
+    setLastTime(Date.now());
+  };
+
+  useEffect(() => {
+    window.addEventListener('input', resetFunction);
+
+    return () => {
+      window.removeEventListener('input', resetFunction);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!lastTime) return;
+    console.log('----time start----');
+
+    const timer = setTimeout(() => {
+      callback();
+    }, timeout);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [lastTime]);
+}

--- a/src/pages/ReviewWrite.tsx
+++ b/src/pages/ReviewWrite.tsx
@@ -3,13 +3,16 @@ import styled from 'styled-components';
 import ReviewEditor from '@/components/ReviewEditor';
 import ReviewAssistant from '@/components/ReviewAssistant';
 import { Margin } from '@/ui/margin/margin';
+import { Comment } from '@/types/Comments';
 
 export default function ReviewWrite() {
+  const [comments, setComments] = useState<Comment[]>([]);
+
   return (
     <Container>
-      <ReviewEditor />
+      <ReviewEditor comments={comments} setComments={setComments} />
       <Margin margin={'0 0 0 20px'} />
-      <ReviewAssistant />
+      <ReviewAssistant comments={comments} />
     </Container>
   );
 }

--- a/src/pages/ReviewWrite.tsx
+++ b/src/pages/ReviewWrite.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components';
 import ReviewEditor from '@/components/ReviewEditor';
 import ReviewAssistant from '@/components/ReviewAssistant';
 import { Margin } from '@/ui/margin/margin';
-import { Comment } from '@/types/Comments';
+import { CommentType } from '@/types/Comments';
 
 export default function ReviewWrite() {
-  const [comments, setComments] = useState<Comment[]>([]);
+  const [comments, setComments] = useState<CommentType[]>([]);
 
   return (
     <Container>
@@ -20,5 +20,6 @@ export default function ReviewWrite() {
 const Container = styled.div`
   width: 90%;
   margin: 0 auto;
+  margin-top: 30px;
   display: flex;
 `;

--- a/src/types/Comments.tsx
+++ b/src/types/Comments.tsx
@@ -1,0 +1,4 @@
+export interface Comment {
+  title: string;
+  content: string;
+}

--- a/src/types/Comments.tsx
+++ b/src/types/Comments.tsx
@@ -1,4 +1,4 @@
-export interface Comment {
-  title: string;
+export interface CommentType {
+  sort: number;
   content: string;
 }


### PR DESCRIPTION
### 관련 이슈
#19 

### 작업 사항
- 사용자가 1초간 입력을 멈출 경우를 감지하여 새로운 추천문장을 띄운다.

### 첨부
> <img width="912" alt="image" src="https://github.com/Review-Mate/Review-Mate-Insert-Module/assets/65444249/e2f7d1c6-23e0-4054-bce8-9c3489be077c">
### 특이사항
> 1. 현재 서버가 완성되지 않은 관계로 서버에서 추천문장이 왔다는 가정하에, 더미 데이터를 이용하여 화면에 띄우는 것 까지 구현을 완료 했습니다.
서버 통신 시간이 반영됐다고 가정하기 위해 지금은 2초 뒤에 추천문장이 뜨도록 설정했습니다. 
-> 추후 1초로 다시 변경할 예정입니다.