### PR TITLE
feat: 부모로 height 상태 전달하는 기능 추가 (related to: #25)

### DIFF
--- a/src/components/KeywordStats/index.tsx
+++ b/src/components/KeywordStats/index.tsx
@@ -8,9 +8,15 @@ import KeywordStatList from './KeywordStatList';
 import { ReactComponent as Down } from '@/assets/icons/down.svg';
 import { ReactComponent as Up } from '@/assets/icons/up.svg';
 
-export default function KeywordStats() {
+interface Props {
+  setHeightChange: (height: boolean) => void;
+}
+
+export default function KeywordStats(props: Props) {
   const limit = 4;
   const [hide, setHide] = useState(true);
+
+  const { setHeightChange } = props;
 
   const keywordList = [
     {
@@ -112,6 +118,7 @@ export default function KeywordStats() {
         <button
           onClick={() => {
             setHide(!hide);
+            setHeightChange(hide);
           }}
         >
           {hide ? <Down /> : <Up />}

--- a/src/components/ReviewSortingList/KeywordSortBar.tsx
+++ b/src/components/ReviewSortingList/KeywordSortBar.tsx
@@ -63,7 +63,7 @@ const BigTag = ({ title, check, onClick }: Props) => {
   return (
     <Tag
       onClick={onClick}
-      backgroundColor={check ? colors.primary : colors.white}
+      backgroundcolor={check ? colors.primary : colors.white}
     >
       {check && <CheckWhite style={{ marginBottom: 2 }} />}
       <Fonts.body3
@@ -79,7 +79,7 @@ const BigTag = ({ title, check, onClick }: Props) => {
 
 const SmallTag = ({ title, check, onClick }: Props) => {
   return (
-    <Tag onClick={onClick} borderColor={check ? colors.gray03 : colors.gray06}>
+    <Tag onClick={onClick} bordercolor={check ? colors.gray03 : colors.gray06}>
       {check && <CheckBlack style={{ marginBottom: 2 }} />}
       <Fonts.body3
         color={colors.gray01}
@@ -92,15 +92,15 @@ const SmallTag = ({ title, check, onClick }: Props) => {
   );
 };
 
-const Tag = styled.button<{ backgroundColor?: string; borderColor?: string }>`
+const Tag = styled.button<{ backgroundcolor?: string; bordercolor?: string }>`
   display: flex;
   align-items: center;
   justify-content: center;
   min-width: 66px;
   height: 30px;
-  border: 1px solid ${(props) => props.borderColor || colors.primary};
+  border: 1px solid ${(props) => props.bordercolor || colors.primary};
   border-radius: 100px;
-  background-color: ${(props) => props.backgroundColor || colors.white};
+  background-color: ${(props) => props.backgroundcolor || colors.white};
   margin: 0 5px 0 0;
   cursor: pointer;
 `;

--- a/src/pages/ReviewList.tsx
+++ b/src/pages/ReviewList.tsx
@@ -2,10 +2,14 @@ import KeywordStats from '@/components/KeywordStats';
 import ReviewSortingList from '@/components/ReviewSortingList';
 import ReviewStats from '@/components/ReviewStats';
 import { Margin } from '@/ui/margin/margin';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { styled } from 'styled-components';
 
 export default function ReviewList() {
+  const componentRef = React.useRef<HTMLDivElement>(null);
+
+  const [heightChange, setHeightChange] = React.useState(false);
+
   const [rating, setRating] = React.useState(5.0);
 
   // 5,4,3,2,1점
@@ -54,11 +58,35 @@ export default function ReviewList() {
     },
   ]);
 
+  useEffect(() => {
+    const handleMessage = (e: MessageEvent) => {
+      if (!e.data.type) return;
+      if (e.data.type === 'loaded') sendHeightToParent();
+      console.log('부모로 부터 온 메세지:', e.data);
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  const sendHeightToParent = () => {
+    if (!componentRef.current) return;
+    const message = componentRef.current?.offsetHeight + 30;
+    window.parent.postMessage({ type: 'height', message: message }, '*');
+  };
+
+  useEffect(() => {
+    sendHeightToParent();
+  }, [heightChange]);
+
   return (
-    <Container>
+    <Container ref={componentRef}>
       <ReviewStats rating={rating} scoreList={scoreList} />
       <Margin margin={'30px 0 0 0'} />
-      <KeywordStats />
+      <KeywordStats setHeightChange={setHeightChange} />
       <Margin margin={'30px 0 0 0'} />
       <ReviewSortingList reviewList={reviewList} />
     </Container>


### PR DESCRIPTION
### 관련 이슈
#25 

### 작업 사항
- 부모로 위젯의 height 전송하기
review status의 개수를 늘리고 줄일 수 있기 때문에 위젯의 height가 변함
-> 부모가 위젯을 삽입할 때 위젯의 height를 지정해줘야 위젯에 스크롤이 생기지 않고 부모 window에서 위젯만큼의 크기를 차지할 수 있음
-> 그러기 위해서 부모에게 위젯의 height를 전달하고, 그 값이 바뀔 때 마다 재전송 하는 프로세스를 구현

### 첨부
> review status의 개수를 늘리고 줄일 때마다 위젯의 변경된 height를 전달받음
>
> <img width="514" alt="image" src="https://github.com/Review-Mate/Review-Mate-Insert-Module/assets/65444249/21dfbb23-91c2-45db-9ab9-88601c78cfa2">


### 특이사항
> 처음 렌더링 시 전달하는 height가 부모 컴포넌트에서 iframe이 load 되기 전에 미리 전달되어 부모에서 받지 못하는 현상이 발생 
-> iframe이 로드되면 부모에서 먼저 자식으로 메세지를 전송 하고, 위젯에서는 메세지를 전송 받은 후에 다시 height를 보내는 방식으로 해결
