### PR TITLE
fix: type에러로 인한 빌드 실패 hotfix

### DIFF
--- a/src/components/ReviewEditor/index.tsx
+++ b/src/components/ReviewEditor/index.tsx
@@ -20,7 +20,7 @@ export default function ReviewEditor(props: Props) {
   const [rating, setRating] = useState<number>(0);
   const [images, setImages] = useState<Array<string>>([]);
 
-  const CommentList = [
+  const CommentList: CommentType[] = [
     {
       sort: 1,
       contents: [

--- a/src/types/Comments.tsx
+++ b/src/types/Comments.tsx
@@ -1,5 +1,7 @@
+import { ReviewAssistType } from '@/config/constants';
+
 export interface CommentType {
-  sort: number;
+  sort: ReviewAssistType;
   idx?: number[];
   contents: string[];
 }


### PR DESCRIPTION
### 관련 이슈
#24 

### 작업 사항
- 타입 에러 해결

### 특이사항
>1. sort의 타입을 ReviewAssistType으로 변경하면서 sort를 요소로 가지고 있던 CommentType이 에러를 일으킴 
-> CommentType의 sort 요소 또한 같은 type으로 변경
>
>2. CommentList의 type명시가 안되어있어서 sort를 number로 자동 타입 추론하여 type에러를 일으킴
-> CommentList의 타입을 CommentType[]으로 명시
