### PR TITLE
fix: (차단됨:mixed-content)	에러 해결

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="upgrade-insecure-requests"
+    />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
## 버그 설명
배포 환경에서 api 요청 시 (차단됨:mixed-content) error가 발생함

## 접근 방법
검색 결과 암호화된 HTTPS 페이지에 암호화되지 않은 HTTP를 통해 요청할 때 발생하는 에러라고 한다.
현재 reviewmate.co.kr 사이트는 https지만 요청을 보내는 서버의 주소는 http로 이루어져 있기 때문에 발생하는 듯 하다.
지금 당장 https로 서버를 만들기는 힘드므로 프론트에서 해당 에러를 제거하기 위해 public/index.tsx에 아래와 같은 메타태그를 추가했다.
<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />

## 관련 사진 첨부
<img width="612" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/f7523881-4117-44ac-a0ff-4d711ebc8511">
<img width="546" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/96c732f5-4485-4af6-971c-fccf327232f1">