### PR TITLE
feat: 부모에게 메세지 전송하는 hook 추가, 리뷰 작성 완료시 사용 (#25)

### DIFF
--- a/src/hooks/useMessageToParent.tsx
+++ b/src/hooks/useMessageToParent.tsx
@@ -4,6 +4,7 @@ export default function useMessageToParent(): {
   componentRef: React.RefObject<HTMLDivElement>;
   setHeightChange: React.Dispatch<React.SetStateAction<number>>;
   heightChange: number;
+  postMessageToParent: (message: string, type: string) => void;
 } {
   const componentRef = useRef<HTMLDivElement>(null);
 
@@ -30,9 +31,14 @@ export default function useMessageToParent(): {
     window.parent.postMessage({ type: 'height', message: message }, '*');
   };
 
+  // 부모에게 메세지 전송
+  const postMessageToParent = (type: string, message: string) => {
+    window.parent.postMessage({ type, message }, '*');
+  };
+
   useEffect(() => {
     sendHeightToParent();
   }, [heightChange]);
 
-  return { componentRef, setHeightChange, heightChange };
+  return { componentRef, setHeightChange, heightChange, postMessageToParent };
 }


### PR DESCRIPTION
### 관련 이슈
#25 

### 작업 사항
- 리뷰 작성 완료시 부모에게 success 메세지 전달

### 첨부
> <img width="881" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/156e15fa-9d17-4f75-891e-6e137caf8332">


### 특이사항
> 부모가 리뷰 작성 완료되었을 때 액션을 취하기 위해 필요
> 기존 useMessageToParent hook에 기능 추가
