### PR TITLE
feat: 리뷰 및 태그 통계 api 연결, 리뷰 페이징 추가 (related to: #34)

### DIFF
--- a/src/components/KeywordStats/KeywordStatList.tsx
+++ b/src/components/KeywordStats/KeywordStatList.tsx
@@ -53,8 +53,10 @@ const Title = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 63px;
   height: 34px;
+  min-width: 63px;
+  padding: 0 10px;
+  margin: 0 15px;
   border-radius: 100px;
   background-color: ${colors.gray06};
 `;

--- a/src/components/KeywordStats/KeywordStatList.tsx
+++ b/src/components/KeywordStats/KeywordStatList.tsx
@@ -24,7 +24,7 @@ export default function KeywordStatList(props: Props) {
       <Bar>
         <KeywordStatBar
           value={negative}
-          max={100}
+          max={positive + negative}
           reverse={1}
           color={colors.red}
         />

--- a/src/components/KeywordStats/index.tsx
+++ b/src/components/KeywordStats/index.tsx
@@ -7,13 +7,27 @@ import { ReactComponent as AIBot } from '@/assets/icons/aibot.svg';
 import KeywordStatList from './KeywordStatList';
 import { ReactComponent as Down } from '@/assets/icons/down.svg';
 import { ReactComponent as Up } from '@/assets/icons/up.svg';
-import { KeywordList } from '@/data/keywordData';
 import useMessageToParent from '@/hooks/useMessageToParent';
+import { useTagStats } from '@/hooks/useStats';
+import { PARTNER_DOMAIN } from '@/config/api';
 
-export default function KeywordStats() {
+interface Props {
+  partnerProductId: string;
+}
+
+export default function KeywordStats({ partnerProductId }: Props) {
   const { setHeightChange, heightChange } = useMessageToParent();
+  const {
+    data: KeywordList,
+    isLoading,
+    isError,
+  } = useTagStats({
+    partnerDomain: PARTNER_DOMAIN,
+    singleTravelProductPartnerCustomId: 'HOTEL-0001',
+  });
 
-  const limit = 4;
+  const TAG_NUMBER_LIMIT = 4;
+
   const [hide, setHide] = useState(true);
 
   return (
@@ -47,42 +61,44 @@ export default function KeywordStats() {
           부정
         </Fonts.caption>
       </StatTitle>
-      {KeywordList.map((keyword, index) => {
-        if (index < limit)
+      {KeywordList?.map((keyword, index) => {
+        if (index < TAG_NUMBER_LIMIT)
           return (
             <div key={index}>
               <Margin margin={'10px 0 0 0'} />
               <KeywordStatList
-                title={keyword.title}
-                positive={keyword.positive}
-                negative={keyword.negative}
+                title={keyword.reviewProperty}
+                positive={keyword.positiveCount}
+                negative={keyword.negativeCount}
               />
             </div>
           );
       })}
       {!hide &&
-        KeywordList.map((keyword, index) => {
-          if (index >= limit)
+        KeywordList?.map((keyword, index) => {
+          if (index >= TAG_NUMBER_LIMIT)
             return (
               <div key={index}>
                 <Margin margin={'10px 0 0 0'} />
                 <KeywordStatList
-                  title={keyword.title}
-                  positive={keyword.positive}
-                  negative={keyword.negative}
+                  title={keyword.reviewProperty}
+                  positive={keyword.positiveCount}
+                  negative={keyword.negativeCount}
                 />
               </div>
             );
         })}
       <DownIcon>
-        <button
-          onClick={() => {
-            setHide(!hide);
-            setHeightChange(heightChange + 1);
-          }}
-        >
-          {hide ? <Down /> : <Up />}
-        </button>
+        {KeywordList && KeywordList?.length > TAG_NUMBER_LIMIT && (
+          <button
+            onClick={() => {
+              setHide(!hide);
+              setHeightChange(heightChange + 1);
+            }}
+          >
+            {hide ? <Down /> : <Up />}
+          </button>
+        )}
       </DownIcon>
     </Container>
   );

--- a/src/components/KeywordStats/index.tsx
+++ b/src/components/KeywordStats/index.tsx
@@ -1,7 +1,7 @@
 import { Margin } from '@/ui/margin/margin';
 import { Fonts } from '@/utils/GlobalFonts';
 import { colors } from '@/utils/GlobalStyles';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { styled } from 'styled-components';
 import { ReactComponent as AIBot } from '@/assets/icons/aibot.svg';
 import KeywordStatList from './KeywordStatList';
@@ -10,20 +10,18 @@ import { ReactComponent as Up } from '@/assets/icons/up.svg';
 import useMessageToParent from '@/hooks/useMessageToParent';
 import { useTagStats } from '@/hooks/useStats';
 import { PARTNER_DOMAIN } from '@/config/api';
+import ProductIdContext from '../contexts/ProductIdContext';
 
-interface Props {
-  partnerProductId: string;
-}
-
-export default function KeywordStats({ partnerProductId }: Props) {
+export default function KeywordStats() {
   const { setHeightChange, heightChange } = useMessageToParent();
+  const partnerProductId = useContext(ProductIdContext);
   const {
     data: KeywordList,
     isLoading,
     isError,
   } = useTagStats({
     partnerDomain: PARTNER_DOMAIN,
-    singleTravelProductPartnerCustomId: 'HOTEL-0001',
+    singleTravelProductPartnerCustomId: partnerProductId,
   });
 
   const TAG_NUMBER_LIMIT = 4;

--- a/src/components/ReviewSortingList/ReviewSortBar.tsx
+++ b/src/components/ReviewSortingList/ReviewSortBar.tsx
@@ -1,27 +1,28 @@
 import { Fonts } from '@/utils/GlobalFonts';
 import { colors } from '@/utils/GlobalStyles';
-import React, { useState } from 'react';
+import React from 'react';
 import { styled } from 'styled-components';
 import { ReactComponent as CheckBlack } from '@/assets/icons/checkBlack.svg';
+import { SORT_OPTIONS } from '@/config/constants';
+import { ReviewSort } from '@/config/enum';
 
-export default function ReviewSortBar() {
-  const [selectedOption, setSelectedOption] = useState(0);
-  const SORT_OPTIONS = [
-    { id: 0, label: '최신순' },
-    { id: 1, label: '별점높은순' },
-    { id: 2, label: '별점낮은순' },
-    { id: 3, label: '긍정률순' },
-    { id: 4, label: '부정률순' },
-  ];
+interface Props {
+  selectedOption: ReviewSort;
+  setSelectedOption: React.Dispatch<React.SetStateAction<ReviewSort>>;
+}
 
+export default function ReviewSortBar({
+  selectedOption,
+  setSelectedOption,
+}: Props) {
   return (
     <Box>
       {SORT_OPTIONS.map((option) => (
         <SortTag
           key={option.id}
-          title={option.label}
-          check={selectedOption === option.id}
-          onClick={() => setSelectedOption(option.id)}
+          title={option.title}
+          check={selectedOption === option.label}
+          onClick={() => setSelectedOption(option.label)}
           divider={option.id < SORT_OPTIONS.length - 1}
         />
       ))}
@@ -29,14 +30,14 @@ export default function ReviewSortBar() {
   );
 }
 
-interface Props {
+interface SortTagProps {
   title: string;
   check: boolean;
   onClick?: () => void;
   divider?: boolean;
 }
 
-const SortTag = ({ title, check, onClick, divider }: Props) => {
+const SortTag = ({ title, check, onClick, divider }: SortTagProps) => {
   return (
     <>
       <Tag onClick={onClick}>

--- a/src/components/ReviewSortingList/Reviews.tsx
+++ b/src/components/ReviewSortingList/Reviews.tsx
@@ -70,7 +70,7 @@ export default function Reviews(props: ReviewType) {
         </Fonts.body3>
         <Fonts.caption color={colors.gray01}>{formatDate}</Fonts.caption>
       </TextBox>
-      <Image src="https://cdn.pixabay.com/photo/2016/03/04/19/36/beach-1236581_1280.jpg" />
+      {/* <Image src="https://cdn.pixabay.com/photo/2016/03/04/19/36/beach-1236581_1280.jpg" /> */}
     </Container>
   );
 }

--- a/src/components/ReviewSortingList/index.tsx
+++ b/src/components/ReviewSortingList/index.tsx
@@ -1,19 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { styled } from 'styled-components';
 import KeywordSort from './KeywordSortBar';
-import ReviewSort from './ReviewSortBar';
 import Reviews from './Reviews';
 import { ReviewType } from '@/types/ReviewType';
+import ReviewSortBar from './ReviewSortBar';
+import { ReviewSort } from '@/config/enum';
 
 interface Props {
   reviewList: ReviewType[];
+  selectedOption: ReviewSort;
+  setSelectedOption: React.Dispatch<React.SetStateAction<ReviewSort>>;
 }
 
-export default function ReviewSortingList(props: Props) {
-  const { reviewList } = props;
+export default function ReviewSortingList({
+  reviewList,
+  selectedOption,
+  setSelectedOption,
+}: Props) {
   return (
     <Container>
-      <ReviewSort />
+      <ReviewSortBar
+        selectedOption={selectedOption}
+        setSelectedOption={setSelectedOption}
+      />
       <KeywordSort />
       {reviewList.map((review: ReviewType) => (
         <Reviews

--- a/src/components/ReviewSortingList/index.tsx
+++ b/src/components/ReviewSortingList/index.tsx
@@ -1,22 +1,35 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { styled } from 'styled-components';
 import KeywordSort from './KeywordSortBar';
 import Reviews from './Reviews';
 import { ReviewType } from '@/types/ReviewType';
 import ReviewSortBar from './ReviewSortBar';
 import { ReviewSort } from '@/config/enum';
+import { Fonts } from '@/utils/GlobalFonts';
 
 interface Props {
   reviewList: ReviewType[];
   selectedOption: ReviewSort;
   setSelectedOption: React.Dispatch<React.SetStateAction<ReviewSort>>;
+  totalPages: number;
+  setSelectedPage: React.Dispatch<React.SetStateAction<number>>;
+  currentPage: number;
 }
 
 export default function ReviewSortingList({
   reviewList,
   selectedOption,
   setSelectedOption,
+  totalPages,
+  setSelectedPage,
+  currentPage,
 }: Props) {
+  const pageButtons = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  const onPageClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setSelectedPage(parseInt(e.currentTarget.value));
+  };
+
   return (
     <Container>
       <ReviewSortBar
@@ -38,6 +51,16 @@ export default function ReviewSortingList({
           reviewHighlightPairResponses={review.reviewHighlightPairResponses}
         />
       ))}
+
+      <PageButtonBox>
+        {pageButtons.map((pageButton) => (
+          <PageButton key={pageButton} value={pageButton} onClick={onPageClick}>
+            <Fonts.body3 weight={currentPage == pageButton ? 900 : 300}>
+              {pageButton}
+            </Fonts.body3>
+          </PageButton>
+        ))}
+      </PageButtonBox>
     </Container>
   );
 }
@@ -49,4 +72,16 @@ const Container = styled.div`
   min-width: 600px;
   align-items: center;
   flex-direction: column;
+`;
+
+const PageButtonBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+`;
+
+const PageButton = styled.button`
+  margin: 0 8px;
+  width: 30px;
+  height: 30px;
 `;

--- a/src/components/ReviewStats/RatingStatBox.tsx
+++ b/src/components/ReviewStats/RatingStatBox.tsx
@@ -15,7 +15,7 @@ interface Props {
   rating: number;
 }
 
-export default function RatingStatBox(props: Props) {
+export default function RatingStatBox({ rating }: Props) {
   const stars = [1, 2, 3, 4, 5];
 
   const starIcons = [
@@ -30,8 +30,6 @@ export default function RatingStatBox(props: Props) {
     star08,
     star09,
   ];
-
-  const { rating } = props;
 
   return (
     <div>

--- a/src/components/ReviewStats/StatBars.tsx
+++ b/src/components/ReviewStats/StatBars.tsx
@@ -8,9 +8,7 @@ interface Props {
   scoreList: number[];
 }
 
-export default function StatBars(props: Props) {
-  const { scoreList } = props;
-
+export default function StatBars({ scoreList }: Props) {
   return (
     <ProgressBox>
       {scoreList.map((score: number, index: number) => (

--- a/src/components/ReviewStats/StatBars.tsx
+++ b/src/components/ReviewStats/StatBars.tsx
@@ -6,15 +6,16 @@ import StatBar from './StatBar';
 
 interface Props {
   scoreList: number[];
+  max: number;
 }
 
-export default function StatBars({ scoreList }: Props) {
+export default function StatBars({ scoreList, max }: Props) {
   return (
     <ProgressBox>
       {scoreList.map((score: number, index: number) => (
         <div key={index}>
           <ProgressGroup>
-            <StatBar value={score} max={100} />
+            <StatBar value={score} max={max} />
             <Margin margin={'5px 0 0 0'} />
             <Fonts.caption>{5 - index}점</Fonts.caption>
           </ProgressGroup>

--- a/src/components/ReviewStats/index.tsx
+++ b/src/components/ReviewStats/index.tsx
@@ -5,31 +5,47 @@ import { colors } from '@/utils/GlobalStyles';
 import React from 'react';
 import { styled } from 'styled-components';
 import RatingStatBox from './RatingStatBox';
+import { PARTNER_DOMAIN } from '@/config/api';
+import { useReviewStats } from '@/hooks/useStats';
 
 interface Props {
-  rating: number;
-  scoreList: number[];
+  partnerProductId: string;
 }
 
-export default function ReviewStats(prop: Props) {
-  const { rating, scoreList } = prop;
+export default function ReviewStats({ partnerProductId }: Props) {
+  const { data: reviewStats, isLoading } = useReviewStats({
+    partnerDomain: PARTNER_DOMAIN,
+    singleTravelProductPartnerCustomId: partnerProductId,
+  });
 
   return (
     <Box>
       <StatItem>
         {/* 점수에 따라 별점 채워짐(0.1 단위) */}
-        <RatingStatBox rating={rating} />
+        {reviewStats && <RatingStatBox rating={reviewStats?.averageRating} />}
         <Margin margin={'5px 0 0 0'} />
-        <Fonts.num2>{rating}</Fonts.num2>
+        {reviewStats && (
+          <Fonts.num2>{reviewStats?.averageRating.toFixed(1)}</Fonts.num2>
+        )}
       </StatItem>
       <StatItem>
         <Fonts.body3>총 리뷰 수</Fonts.body3>
         <Margin margin={'10px 0 0 0'} />
-        <Fonts.num2>4500</Fonts.num2>
+        {reviewStats && <Fonts.num2>{reviewStats?.reviewCount}</Fonts.num2>}
       </StatItem>
       <StatItem>
         {/* 전체가 100, 퍼센트(%)만큼 채워짐 */}
-        <StatBars scoreList={scoreList} />
+        {reviewStats && (
+          <StatBars
+            scoreList={[
+              reviewStats?.fiveStarRatingCount,
+              reviewStats?.fourStarRatingCount,
+              reviewStats?.threeStarRatingCount,
+              reviewStats?.twoStarRatingCount,
+              reviewStats?.oneStarRatingCount,
+            ]}
+          />
+        )}
       </StatItem>
     </Box>
   );

--- a/src/components/ReviewStats/index.tsx
+++ b/src/components/ReviewStats/index.tsx
@@ -2,17 +2,16 @@ import StatBars from '@/components/ReviewStats/StatBars';
 import { Margin } from '@/ui/margin/margin';
 import { Fonts } from '@/utils/GlobalFonts';
 import { colors } from '@/utils/GlobalStyles';
-import React from 'react';
+import React, { useContext } from 'react';
 import { styled } from 'styled-components';
 import RatingStatBox from './RatingStatBox';
 import { PARTNER_DOMAIN } from '@/config/api';
 import { useReviewStats } from '@/hooks/useStats';
+import ProductIdContext from '../contexts/ProductIdContext';
 
-interface Props {
-  partnerProductId: string;
-}
+export default function ReviewStats() {
+  const partnerProductId = useContext(ProductIdContext);
 
-export default function ReviewStats({ partnerProductId }: Props) {
   const { data: reviewStats, isLoading } = useReviewStats({
     partnerDomain: PARTNER_DOMAIN,
     singleTravelProductPartnerCustomId: partnerProductId,

--- a/src/components/ReviewStats/index.tsx
+++ b/src/components/ReviewStats/index.tsx
@@ -34,7 +34,7 @@ export default function ReviewStats({ partnerProductId }: Props) {
         {reviewStats && <Fonts.num2>{reviewStats?.reviewCount}</Fonts.num2>}
       </StatItem>
       <StatItem>
-        {/* 전체가 100, 퍼센트(%)만큼 채워짐 */}
+        {/* 전체 리뷰 수를 100으로, 퍼센트(%)만큼 채워짐 */}
         {reviewStats && (
           <StatBars
             scoreList={[
@@ -44,6 +44,7 @@ export default function ReviewStats({ partnerProductId }: Props) {
               reviewStats?.twoStarRatingCount,
               reviewStats?.oneStarRatingCount,
             ]}
+            max={reviewStats?.reviewCount}
           />
         )}
       </StatItem>

--- a/src/components/contexts/ProductIdContext.tsx
+++ b/src/components/contexts/ProductIdContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+const ProductIdContext = createContext('');
+
+export const ProductIdProvider = ProductIdContext.Provider;
+export const ProductIdConsumer = ProductIdContext.Consumer;
+
+export default ProductIdContext;

--- a/src/config/constants.tsx
+++ b/src/config/constants.tsx
@@ -1,2 +1,13 @@
+import { ReviewSort } from './enum';
+
 // 데모 리뷰 조회용 상품 id
 export const PARTNER_CUSTOM_PRODUCT_ID = 'PRODUCT-0001';
+
+// 리뷰 정렬 옵션
+export const SORT_OPTIONS = [
+  { id: 0, title: '최신순', label: ReviewSort.LATEST },
+  { id: 1, title: '별점높은순', label: ReviewSort.RATING_DESC },
+  { id: 2, title: '별점낮은순', label: ReviewSort.RATING_ASC },
+  { id: 3, title: '긍정률순', label: ReviewSort.POSITIVE_DESC },
+  { id: 4, title: '부정률순', label: ReviewSort.NEGATIVE_DESC },
+];

--- a/src/config/enum.tsx
+++ b/src/config/enum.tsx
@@ -9,10 +9,10 @@ export type ReviewAssistType = keyof typeof ReviewAssist | number;
 // 리뷰 목록 정렬
 export enum ReviewSort {
   LATEST = 'LATEST',
-  RATING_ASC = 'RATING_ASC',
   RATING_DESC = 'RATING_DESC',
-  POSITIVE = 'POSITIVE',
-  NEGATIVE = 'NEGATIVE',
+  RATING_ASC = 'RATING_ASC',
+  POSITIVE_DESC = 'POSITIVE_DESC',
+  NEGATIVE_DESC = 'NEGATIVE_DESC',
 }
 
 export type ReviewSortType = keyof typeof ReviewSort;

--- a/src/hooks/useReviews.tsx
+++ b/src/hooks/useReviews.tsx
@@ -63,7 +63,9 @@ export const useProductReviews = ({
   reviewPage = 0,
   reviewListSize = 10,
   onSuccess,
-}: FetchProductReviews & { onSuccess?: () => void }) => {
+}: FetchProductReviews & {
+  onSuccess?: (data: ReviewListSortType) => void;
+}) => {
   return useQuery<ReviewListSortType, Error>(
     ['productReviews', partnerDomain, travelProductPartnerCustomId],
     () =>

--- a/src/hooks/useStats.tsx
+++ b/src/hooks/useStats.tsx
@@ -1,0 +1,77 @@
+import { useQuery, useMutation } from 'react-query';
+import axios from 'axios';
+import { BASE_URL } from '@/config/api';
+import { ReviewStatsType, TagStatsType } from '@/types/ReviewType';
+
+interface FetchStats {
+  partnerDomain: string;
+  singleTravelProductPartnerCustomId: string;
+}
+
+// 단일 여행 상품에 등록된 리뷰 통계 조회
+const fetchReviewStats = async ({
+  partnerDomain,
+  singleTravelProductPartnerCustomId,
+}: FetchStats): Promise<ReviewStatsType> => {
+  const { data } = await axios.get(
+    `${BASE_URL}/api/widget/v1/${partnerDomain}/products/${singleTravelProductPartnerCustomId}/statistic/reviews`
+  );
+  return data;
+};
+
+// 단일 여행 상품에 등록된 태그 통계 조회
+const fetchTagStats = async ({
+  partnerDomain,
+  singleTravelProductPartnerCustomId,
+}: FetchStats): Promise<TagStatsType[]> => {
+  const { data } = await axios.get(
+    `${BASE_URL}/api/widget/v1/${partnerDomain}/products/${singleTravelProductPartnerCustomId}/statistics/tags`
+  );
+  return data;
+};
+
+// 단일 여행 상품에 등록된 리뷰 통계 조회
+export const useReviewStats = ({
+  partnerDomain,
+  singleTravelProductPartnerCustomId,
+}: FetchStats) => {
+  return useQuery<ReviewStatsType, Error>(
+    ['reviewStats', partnerDomain, singleTravelProductPartnerCustomId],
+    () =>
+      fetchReviewStats({
+        partnerDomain,
+        singleTravelProductPartnerCustomId,
+      }),
+    {
+      onSuccess: () => {
+        console.log('태그 통계 불러오기 성공');
+      },
+      onError: (error) => {
+        console.log('태그 통계 불러오기 실패', error);
+      },
+    }
+  );
+};
+
+// 단일 여행 상품에 등록된 태그 통계 조회
+export const useTagStats = ({
+  partnerDomain,
+  singleTravelProductPartnerCustomId,
+}: FetchStats) => {
+  return useQuery<TagStatsType[], Error>(
+    ['tagStats', partnerDomain, singleTravelProductPartnerCustomId],
+    () =>
+      fetchTagStats({
+        partnerDomain,
+        singleTravelProductPartnerCustomId,
+      }),
+    {
+      onSuccess: () => {
+        console.log('태그 통계 불러오기 성공');
+      },
+      onError: (error) => {
+        console.log('태그 통계 불러오기 실패', error);
+      },
+    }
+  );
+};

--- a/src/pages/ReviewList.tsx
+++ b/src/pages/ReviewList.tsx
@@ -3,11 +3,12 @@ import ReviewSortingList from '@/components/ReviewSortingList';
 import ReviewStats from '@/components/ReviewStats';
 import ProductIdContext from '@/components/contexts/ProductIdContext';
 import { PARTNER_DOMAIN } from '@/config/api';
+import { ReviewSort } from '@/config/enum';
 import useMessageToParent from '@/hooks/useMessageToParent';
 import { useProductReviews } from '@/hooks/useReviews';
 import { Margin } from '@/ui/margin/margin';
 import { Fonts } from '@/utils/GlobalFonts';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
@@ -19,16 +20,26 @@ export default function ReviewList() {
     'product_id'
   );
 
+  // 선택된 리뷰 정렬 옵션
+  const [selectedOption, setSelectedOption] = useState<ReviewSort>(
+    ReviewSort.LATEST
+  );
+
   // 상품 리뷰 목록 조회
-  const { data, isLoading } = partnerProductId
+  const { data, isLoading, refetch } = partnerProductId
     ? useProductReviews({
         partnerDomain: PARTNER_DOMAIN,
         travelProductPartnerCustomId: partnerProductId,
+        reviewSort: selectedOption,
         onSuccess: () => {
           setHeightChange(heightChange + 1);
         },
       })
-    : { data: null, isLoading: true };
+    : { data: null, isLoading: true, refetch: undefined };
+
+  useEffect(() => {
+    if (refetch) refetch();
+  }, [selectedOption]);
 
   if (partnerProductId)
     return (
@@ -43,7 +54,11 @@ export default function ReviewList() {
           <Margin margin={'30px 0 0 0'} />
           {isLoading && <div>로딩중</div>}
           {!isLoading && data && (
-            <ReviewSortingList reviewList={data?.content} />
+            <ReviewSortingList
+              reviewList={data?.content}
+              selectedOption={selectedOption}
+              setSelectedOption={setSelectedOption}
+            />
           )}
         </Container>
       </ProductIdContext.Provider>

--- a/src/pages/ReviewList.tsx
+++ b/src/pages/ReviewList.tsx
@@ -4,10 +4,9 @@ import ReviewStats from '@/components/ReviewStats';
 import { PARTNER_DOMAIN } from '@/config/api';
 import useMessageToParent from '@/hooks/useMessageToParent';
 import { useProductReviews } from '@/hooks/useReviews';
-import { SCORE_AVE, SCORE_LIST } from '@/temp/constant';
 import { Margin } from '@/ui/margin/margin';
 import { Fonts } from '@/utils/GlobalFonts';
-import React, { useState } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
@@ -35,9 +34,9 @@ export default function ReviewList() {
       <Title>
         <Fonts.body1>리뷰</Fonts.body1>
       </Title>
-      <ReviewStats rating={SCORE_AVE} scoreList={SCORE_LIST} />
+      {partnerProductId && <ReviewStats partnerProductId={partnerProductId} />}
       <Margin margin={'30px 0 0 0'} />
-      <KeywordStats />
+      {partnerProductId && <KeywordStats partnerProductId={partnerProductId} />}
       <Margin margin={'30px 0 0 0'} />
       {isLoading && <div>로딩중</div>}
       {!isLoading && data && <ReviewSortingList reviewList={data?.content} />}

--- a/src/pages/ReviewList.tsx
+++ b/src/pages/ReviewList.tsx
@@ -1,6 +1,7 @@
 import KeywordStats from '@/components/KeywordStats';
 import ReviewSortingList from '@/components/ReviewSortingList';
 import ReviewStats from '@/components/ReviewStats';
+import ProductIdContext from '@/components/contexts/ProductIdContext';
 import { PARTNER_DOMAIN } from '@/config/api';
 import useMessageToParent from '@/hooks/useMessageToParent';
 import { useProductReviews } from '@/hooks/useReviews';
@@ -29,19 +30,26 @@ export default function ReviewList() {
       })
     : { data: null, isLoading: true };
 
-  return (
-    <Container ref={componentRef}>
-      <Title>
-        <Fonts.body1>리뷰</Fonts.body1>
-      </Title>
-      {partnerProductId && <ReviewStats partnerProductId={partnerProductId} />}
-      <Margin margin={'30px 0 0 0'} />
-      {partnerProductId && <KeywordStats partnerProductId={partnerProductId} />}
-      <Margin margin={'30px 0 0 0'} />
-      {isLoading && <div>로딩중</div>}
-      {!isLoading && data && <ReviewSortingList reviewList={data?.content} />}
-    </Container>
-  );
+  if (partnerProductId)
+    return (
+      <ProductIdContext.Provider value={partnerProductId}>
+        <Container ref={componentRef}>
+          <Title>
+            <Fonts.body1>리뷰</Fonts.body1>
+          </Title>
+          <ReviewStats />
+          <Margin margin={'30px 0 0 0'} />
+          <KeywordStats />
+          <Margin margin={'30px 0 0 0'} />
+          {isLoading && <div>로딩중</div>}
+          {!isLoading && data && (
+            <ReviewSortingList reviewList={data?.content} />
+          )}
+        </Container>
+      </ProductIdContext.Provider>
+    );
+
+  return <div>상품 아이디가 존재하지 않습니다.</div>;
 }
 
 const Title = styled.div`

--- a/src/pages/ReviewList.tsx
+++ b/src/pages/ReviewList.tsx
@@ -25,21 +25,28 @@ export default function ReviewList() {
     ReviewSort.LATEST
   );
 
+  // 선택된 페이지 번호
+  const [selectedPage, setSelectedPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
+
   // 상품 리뷰 목록 조회
   const { data, isLoading, refetch } = partnerProductId
     ? useProductReviews({
         partnerDomain: PARTNER_DOMAIN,
         travelProductPartnerCustomId: partnerProductId,
         reviewSort: selectedOption,
-        onSuccess: () => {
+        reviewPage: selectedPage - 1,
+        onSuccess: (data) => {
           setHeightChange(heightChange + 1);
+          setCurrentPage(data.pageable.pageNumber + 1);
         },
       })
     : { data: null, isLoading: true, refetch: undefined };
 
+  console.log(data);
   useEffect(() => {
     if (refetch) refetch();
-  }, [selectedOption]);
+  }, [selectedOption, selectedPage]);
 
   if (partnerProductId)
     return (
@@ -58,6 +65,9 @@ export default function ReviewList() {
               reviewList={data?.content}
               selectedOption={selectedOption}
               setSelectedOption={setSelectedOption}
+              totalPages={data?.totalPages}
+              setSelectedPage={setSelectedPage}
+              currentPage={currentPage}
             />
           )}
         </Container>

--- a/src/types/ReviewType.tsx
+++ b/src/types/ReviewType.tsx
@@ -44,3 +44,19 @@ export interface ReviewListSortType {
   totalElements: number;
   totalPages: number;
 }
+
+export interface TagStatsType {
+  reviewProperty: string;
+  positiveCount: number;
+  negativeCount: number;
+}
+
+export interface ReviewStatsType {
+  averageRating: number;
+  reviewCount: number;
+  fiveStarRatingCount: number;
+  fourStarRatingCount: number;
+  threeStarRatingCount: number;
+  twoStarRatingCount: number;
+  oneStarRatingCount: number;
+}


### PR DESCRIPTION
### 관련 이슈
#34

### 작업 사항
- 리뷰 및 태그 통계 api 연결
- 리뷰 페이징 추가

### 첨부
> <img width="1231" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/33f4bf12-15f4-4003-8b97-dda179a2f978">

### 특이사항
> 태그 통계 부분 기준 개수인 max가 현재는 100으로 되어있는 상태인데, 이를 전체 태그의 총 개수로 바꿀 예정이었음,
그런데 지금처럼 태그가 1개 밖에 없는데도 그래프가 끝까지 차는 것은 직관적이지 않을 듯해서 이 부분은 더 고민 필요

### 10/6일 데일리스크럼에서 논의한 결과
-> 그래프의 목적이 긍/부정의 비율을 직관적으로 보는 것이 목적이므로, max를 각 태그의 긍+부정 개수를 합친 것으로 설정하기로 결정
