### PR TITLE
fix: 하단의 페이지 이동 버튼의 높이가 전송되지 않아 잘리는 현상 해결 

### DIFF
--- a/src/components/KeywordStats/index.tsx
+++ b/src/components/KeywordStats/index.tsx
@@ -7,7 +7,6 @@ import { ReactComponent as AIBot } from '@/assets/icons/aibot.svg';
 import KeywordStatList from './KeywordStatList';
 import { ReactComponent as Down } from '@/assets/icons/down.svg';
 import { ReactComponent as Up } from '@/assets/icons/up.svg';
-import useMessageToParent from '@/hooks/useMessageToParent';
 import { useTagStats } from '@/hooks/useStats';
 import ProductIdContext from '../contexts/ProductIdContext';
 
@@ -16,8 +15,6 @@ interface Props {
 }
 
 export default function KeywordStats({ reviewCount }: Props) {
-  const { setHeightChange, heightChange } = useMessageToParent();
-
   const { partnerDomain, partnerProductId } = useContext(ProductIdContext);
   const {
     data: KeywordList,
@@ -108,7 +105,6 @@ export default function KeywordStats({ reviewCount }: Props) {
           <button
             onClick={() => {
               setHide(!hide);
-              setHeightChange(heightChange + 1);
             }}
           >
             {hide ? <Down /> : <Up />}

--- a/src/hooks/useHeightToParent.tsx
+++ b/src/hooks/useHeightToParent.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export default function useHeightToParent(): {
+  componentRef: React.RefObject<HTMLDivElement>;
+} {
+  const componentRef = useRef<HTMLDivElement>(null);
+
+  const [heightChange, setHeightChange] = useState(0);
+
+  // iframe 로드되면 height 전송
+  useEffect(() => {
+    const handleMessage = (e: MessageEvent) => {
+      if (!e.data.type) return;
+      if (e.data.type === 'loaded') sendHeightToParent();
+    };
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  // height 변경 감지
+  useEffect(() => {
+    if (componentRef.current) resizeObserver.observe(componentRef.current);
+  }, [componentRef]);
+
+  // height 바뀔 때마다 자동으로 부모에게 height값 전송
+  useEffect(() => {
+    sendHeightToParent();
+  }, [heightChange]);
+
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const { height } = entry.contentRect;
+      setHeightChange(height + 30);
+    }
+  });
+
+  const sendHeightToParent = () => {
+    if (!componentRef.current) return;
+    window.parent.postMessage({ type: 'height', message: heightChange }, '*');
+  };
+
+  return { componentRef };
+}

--- a/src/hooks/useMessageToParent.tsx
+++ b/src/hooks/useMessageToParent.tsx
@@ -1,54 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react';
-
 interface messageType {
   type?: string;
   message: string;
 }
 
 export default function useMessageToParent(): {
-  componentRef: React.RefObject<HTMLDivElement>;
-  setHeightChange: React.Dispatch<React.SetStateAction<number>>;
-  heightChange: number;
   sendMessageToParent: ({ type, message }: messageType) => void;
 } {
-  const componentRef = useRef<HTMLDivElement>(null);
-
-  const [heightChange, setHeightChange] = useState(0);
-
-  useEffect(() => {
-    const handleMessage = (e: MessageEvent) => {
-      if (!e.data.type) return;
-      if (e.data.type === 'loaded') sendHeightToParent();
-    };
-
-    window.addEventListener('message', handleMessage);
-
-    return () => {
-      window.removeEventListener('message', handleMessage);
-    };
-  }, []);
-
   // 부모에게 메시지 전송
   const sendMessageToParent = ({ type = 'success', message }: messageType) => {
     if (!message) return;
     window.parent.postMessage({ type: type, message: message }, '*');
   };
 
-  // height 바뀔 때마다 자동으로 부모에게 height값 전송
-  const sendHeightToParent = () => {
-    if (!componentRef.current) return;
-    const message = componentRef.current?.offsetHeight + 30;
-    window.parent.postMessage({ type: 'height', message: message }, '*');
-  };
-
-  // 부모에게 메세지 전송
-  const postMessageToParent = (type: string, message: string) => {
-    window.parent.postMessage({ type, message }, '*');
-  };
-
-  useEffect(() => {
-    sendHeightToParent();
-  }, [heightChange]);
-
-  return { componentRef, setHeightChange, heightChange, sendMessageToParent };
+  return { sendMessageToParent };
 }

--- a/src/pages/ReviewList.tsx
+++ b/src/pages/ReviewList.tsx
@@ -3,7 +3,6 @@ import ReviewSortingList from '@/components/ReviewSortingList';
 import ReviewStats from '@/components/ReviewStats';
 import ProductIdContext from '@/components/contexts/ProductIdContext';
 import { ReviewSort } from '@/config/enum';
-import useMessageToParent from '@/hooks/useMessageToParent';
 import { useProductReviews } from '@/hooks/useReviews';
 import { Margin } from '@/ui/margin/margin';
 import { Fonts } from '@/utils/GlobalFonts';
@@ -12,9 +11,10 @@ import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 import LoadingBar from '@/ui/loadingBar/LoadingBar';
 import ProductTagContext from '@/components/contexts/ProductTagContext';
+import useHeightToParent from '@/hooks/useHeightToParent';
 
 export default function ReviewList() {
-  const { componentRef, setHeightChange, heightChange } = useMessageToParent();
+  const { componentRef } = useHeightToParent();
   const location = useLocation();
 
   const params = new URLSearchParams(location.search);
@@ -44,7 +44,6 @@ export default function ReviewList() {
           property: selectedBigTag,
           keyword: selectedTag,
           onSuccess: (data) => {
-            setHeightChange(heightChange + 1);
             setCurrentPage(data.pageable.pageNumber + 1);
           },
         })

--- a/src/pages/ReviewWrite.tsx
+++ b/src/pages/ReviewWrite.tsx
@@ -4,10 +4,10 @@ import ReviewEditor from '@/components/ReviewEditor';
 import ReviewAssistant from '@/components/ReviewAssistant';
 import { Margin } from '@/ui/margin/margin';
 import { CommentType } from '@/types/Comments';
-import useMessageToParent from '@/hooks/useMessageToParent';
+import useHeightToParent from '@/hooks/useHeightToParent';
 
 export default function ReviewWrite() {
-  const { componentRef } = useMessageToParent();
+  const { componentRef } = useHeightToParent();
 
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');


### PR DESCRIPTION
## 버그 설명
하단의 페이지 이동 버튼이 부모 서비스에서 나타나지 않는 현상 발생

## 접근 방법
페이지 이동 버튼은 분명 제대로 랜더링 되는데, 부모 페이지에서 나타나지 않음 ->  높이 계산에 오류가 있을 가능성

=>컴포넌트 높이 전송을 확인해 본 결과, 페이지 이동 버튼의 렌더링이 끝나지 않았을 때 높이 전송이 이루어져서, 하단의 버튼이 잘리는 현상 파악

=> 따라서 기존 리스트가 업데이트 될 때마다 height를 갱신하도록 했던 방법에서
-> 리스트를 감싸고 있는 container의 높이에 변화가 생기는 걸 감지하여 height 갱신하는 방식으로 변경
+ height 전송 로직이 복잡해짐에 따라 message 전송 hook과 분리

## 관련 사진 첨부
수정 전
<img width="1186" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/7a9cf3e3-0509-4ec6-b761-6524bbc9e0c6">
수정 후
<img width="1193" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/6b48c763-a44b-4125-af8b-2e0f9c4b20df">
