### PR TITLE
[빌드21] fix: 하단의 페이지 이동 버튼 에러 해결

### DIFF
--- a/src/components/KeywordStats/index.tsx
+++ b/src/components/KeywordStats/index.tsx
@@ -7,7 +7,6 @@ import { ReactComponent as AIBot } from '@/assets/icons/aibot.svg';
 import KeywordStatList from './KeywordStatList';
 import { ReactComponent as Down } from '@/assets/icons/down.svg';
 import { ReactComponent as Up } from '@/assets/icons/up.svg';
-import useMessageToParent from '@/hooks/useMessageToParent';
 import { useTagStats } from '@/hooks/useStats';
 import ProductIdContext from '../contexts/ProductIdContext';
 
@@ -16,8 +15,6 @@ interface Props {
 }
 
 export default function KeywordStats({ reviewCount }: Props) {
-  const { setHeightChange, heightChange } = useMessageToParent();
-
   const { partnerDomain, partnerProductId } = useContext(ProductIdContext);
   const {
     data: KeywordList,
@@ -108,7 +105,6 @@ export default function KeywordStats({ reviewCount }: Props) {
           <button
             onClick={() => {
               setHide(!hide);
-              setHeightChange(heightChange + 1);
             }}
           >
             {hide ? <Down /> : <Up />}

--- a/src/hooks/useHeightToParent.tsx
+++ b/src/hooks/useHeightToParent.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export default function useHeightToParent(): {
+  componentRef: React.RefObject<HTMLDivElement>;
+} {
+  const componentRef = useRef<HTMLDivElement>(null);
+
+  const [heightChange, setHeightChange] = useState(0);
+
+  // iframe 로드되면 height 전송
+  useEffect(() => {
+    const handleMessage = (e: MessageEvent) => {
+      if (!e.data.type) return;
+      if (e.data.type === 'loaded') sendHeightToParent();
+    };
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  // height 변경 감지
+  useEffect(() => {
+    if (componentRef.current) resizeObserver.observe(componentRef.current);
+  }, [componentRef]);
+
+  // height 바뀔 때마다 자동으로 부모에게 height값 전송
+  useEffect(() => {
+    sendHeightToParent();
+  }, [heightChange]);
+
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const { height } = entry.contentRect;
+      setHeightChange(height + 30);
+    }
+  });
+
+  const sendHeightToParent = () => {
+    if (!componentRef.current) return;
+    window.parent.postMessage({ type: 'height', message: heightChange }, '*');
+  };
+
+  return { componentRef };
+}

--- a/src/hooks/useMessageToParent.tsx
+++ b/src/hooks/useMessageToParent.tsx
@@ -1,54 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react';
-
 interface messageType {
   type?: string;
   message: string;
 }
 
 export default function useMessageToParent(): {
-  componentRef: React.RefObject<HTMLDivElement>;
-  setHeightChange: React.Dispatch<React.SetStateAction<number>>;
-  heightChange: number;
   sendMessageToParent: ({ type, message }: messageType) => void;
 } {
-  const componentRef = useRef<HTMLDivElement>(null);
-
-  const [heightChange, setHeightChange] = useState(0);
-
-  useEffect(() => {
-    const handleMessage = (e: MessageEvent) => {
-      if (!e.data.type) return;
-      if (e.data.type === 'loaded') sendHeightToParent();
-    };
-
-    window.addEventListener('message', handleMessage);
-
-    return () => {
-      window.removeEventListener('message', handleMessage);
-    };
-  }, []);
-
   // 부모에게 메시지 전송
   const sendMessageToParent = ({ type = 'success', message }: messageType) => {
     if (!message) return;
     window.parent.postMessage({ type: type, message: message }, '*');
   };
 
-  // height 바뀔 때마다 자동으로 부모에게 height값 전송
-  const sendHeightToParent = () => {
-    if (!componentRef.current) return;
-    const message = componentRef.current?.offsetHeight + 30;
-    window.parent.postMessage({ type: 'height', message: message }, '*');
-  };
-
-  // 부모에게 메세지 전송
-  const postMessageToParent = (type: string, message: string) => {
-    window.parent.postMessage({ type, message }, '*');
-  };
-
-  useEffect(() => {
-    sendHeightToParent();
-  }, [heightChange]);
-
-  return { componentRef, setHeightChange, heightChange, sendMessageToParent };
+  return { sendMessageToParent };
 }

--- a/src/pages/ReviewList.tsx
+++ b/src/pages/ReviewList.tsx
@@ -3,7 +3,6 @@ import ReviewSortingList from '@/components/ReviewSortingList';
 import ReviewStats from '@/components/ReviewStats';
 import ProductIdContext from '@/components/contexts/ProductIdContext';
 import { ReviewSort } from '@/config/enum';
-import useMessageToParent from '@/hooks/useMessageToParent';
 import { useProductReviews } from '@/hooks/useReviews';
 import { Margin } from '@/ui/margin/margin';
 import { Fonts } from '@/utils/GlobalFonts';
@@ -12,9 +11,10 @@ import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 import LoadingBar from '@/ui/loadingBar/LoadingBar';
 import ProductTagContext from '@/components/contexts/ProductTagContext';
+import useHeightToParent from '@/hooks/useHeightToParent';
 
 export default function ReviewList() {
-  const { componentRef, setHeightChange, heightChange } = useMessageToParent();
+  const { componentRef } = useHeightToParent();
   const location = useLocation();
 
   const params = new URLSearchParams(location.search);
@@ -44,7 +44,6 @@ export default function ReviewList() {
           property: selectedBigTag,
           keyword: selectedTag,
           onSuccess: (data) => {
-            setHeightChange(heightChange + 1);
             setCurrentPage(data.pageable.pageNumber + 1);
           },
         })

--- a/src/pages/ReviewWrite.tsx
+++ b/src/pages/ReviewWrite.tsx
@@ -4,10 +4,10 @@ import ReviewEditor from '@/components/ReviewEditor';
 import ReviewAssistant from '@/components/ReviewAssistant';
 import { Margin } from '@/ui/margin/margin';
 import { CommentType } from '@/types/Comments';
-import useMessageToParent from '@/hooks/useMessageToParent';
+import useHeightToParent from '@/hooks/useHeightToParent';
 
 export default function ReviewWrite() {
-  const { componentRef } = useMessageToParent();
+  const { componentRef } = useHeightToParent();
 
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');


### PR DESCRIPTION
### 관련 pr
#50 

### 내용
기존 하단 페이지 이동 버튼이 나오지 않던 에러를 해결했습니다.
