### PR TITLE
fix: 리뷰 하이라이트 중복 예외 및 css 수정

### DIFF
--- a/src/components/ReviewSortingList/Reviews.tsx
+++ b/src/components/ReviewSortingList/Reviews.tsx
@@ -34,6 +34,7 @@ export default function Reviews({
     const sentence = [];
     let lastIndex = 0;
     indexList?.forEach((index) => {
+      if (lastIndex > index.startIndex) return;
       sentence.push(content.slice(lastIndex, index.startIndex));
       sentence.push(
         <Highlight>{content.slice(index.startIndex, index.endIndex)}</Highlight>

--- a/src/utils/tagMatch.tsx
+++ b/src/utils/tagMatch.tsx
@@ -3,8 +3,8 @@ interface ReviewTagMatch {
 }
 
 export const reviewTagMatch: ReviewTagMatch = {
-  KINDNESS: '친절도',
-  ROOM: '방/객실/청결도',
+  KINDNESS: '친절',
+  ROOM: '객실/청결',
   RESTROOM: '화장실',
   LOCATION: '위치',
   SIGHT: '풍경',


### PR DESCRIPTION
### 관련 이슈

### 작업 사항
리뷰 하이라이트 중복되는 오류 해결 -> 중복된 인덱스 들어왔을 경우 패스
키워드 통계 부분 글자수로 인해 css 깨지는 부분 수정

### 첨부 파일
><img width="946" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/f87d4946-8b81-444a-9f4d-9523e08b7cfa">
><img width="941" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/c62e4965-42b4-4cbb-84a8-ee7622e0c37e">


><img width="903" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/b99ff453-cdb0-47d0-abf5-73d521ce72ef">
><img width="908" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/a3115043-03dc-4c46-afa7-e34b9c1d8652">
