### PR TITLE
fix) 리뷰 목록 위젯, 별점/통계/태그 부분 에러 해결

### DIFF
--- a/public/script/widgetScript.js
+++ b/public/script/widgetScript.js
@@ -9,6 +9,7 @@ const createIframe = ($widgetContainer, type) => {
   iframe.style.width = '100%';
   iframe.style.height = '0';
   iframe.style.border = 'none';
+  iframe.scrolling = 'no';
 
   return iframe;
 };

--- a/src/components/KeywordStats/KeywordStatBar.tsx
+++ b/src/components/KeywordStats/KeywordStatBar.tsx
@@ -44,7 +44,8 @@ const Circle = styled.div<{ color?: string; reverse?: number }>`
   justify-content: center;
   align-items: center;
   border-radius: 100px;
-  width: 26px;
+  padding: 0 5px;
+  min-width: 16px;
   height: 26px;
   background-color: ${(props) => props.color || colors.primary};
 `;

--- a/src/components/KeywordStats/index.tsx
+++ b/src/components/KeywordStats/index.tsx
@@ -89,12 +89,13 @@ export default function KeywordStats({ reviewCount }: Props) {
       })}
       {!hide &&
         KeywordList?.map((keyword, index) => {
-          if (index >= TAG_NUMBER_LIMIT)
+          const tag = reviewTagMatch[keyword.reviewProperty];
+          if (tag !== undefined && TAG_NUMBER_LIMIT <= index && index < 7)
             return (
               <div key={index}>
                 <Margin margin={'10px 0 0 0'} />
                 <KeywordStatList
-                  title={keyword.reviewProperty}
+                  title={tag}
                   positive={keyword.positiveCount}
                   negative={keyword.negativeCount}
                   max={maxCount}

--- a/src/components/ReviewSortingList/KeywordSortBar.tsx
+++ b/src/components/ReviewSortingList/KeywordSortBar.tsx
@@ -37,21 +37,20 @@ export default function KeywordSortBar({ setSelectedPage }: Props) {
             const tag = reviewTagMatch[tagName];
             if (tag === undefined) return;
             return (
-              <React.Fragment key={index}>
-                <BigTag
-                  title={tag}
-                  check={selectedBigTag === tagName}
-                  onClick={() => {
+              <BigTag
+                key={index}
+                title={tag}
+                check={selectedBigTag === tagName}
+                onClick={() => {
+                  setSelectedTag('');
+                  if (selectedBigTag === tagName) {
+                    setSelectedBigTag('');
                     setSelectedTag('');
-                    if (selectedBigTag === tagName) {
-                      setSelectedBigTag('');
-                      setSelectedTag('');
-                      return;
-                    }
-                    setSelectedBigTag(tagName);
-                  }}
-                />
-              </React.Fragment>
+                    return;
+                  }
+                  setSelectedBigTag(tagName);
+                }}
+              />
             );
           })}
       </BigBox>
@@ -59,20 +58,19 @@ export default function KeywordSortBar({ setSelectedPage }: Props) {
         <SmallBox>
           {tagsData &&
             tagsData[selectedBigTag]?.map((smallTag, index) => (
-              <React.Fragment key={index}>
-                <SmallTag
-                  title={smallTag}
-                  check={selectedTag === smallTag}
-                  onClick={() => {
-                    if (selectedTag === smallTag) {
-                      setSelectedTag('');
-                      return;
-                    }
-                    setSelectedPage(1);
-                    setSelectedTag(smallTag);
-                  }}
-                />
-              </React.Fragment>
+              <SmallTag
+                key={index}
+                title={smallTag}
+                check={selectedTag === smallTag}
+                onClick={() => {
+                  if (selectedTag === smallTag) {
+                    setSelectedTag('');
+                    return;
+                  }
+                  setSelectedPage(1);
+                  setSelectedTag(smallTag);
+                }}
+              />
             ))}
         </SmallBox>
       )}
@@ -97,6 +95,11 @@ const BigTag = ({ title, check, onClick }: TagProps) => {
         color={check ? colors.white : colors.primary}
         weight={500}
         margin={check ? '0 0 0 4px' : '0'}
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
       >
         {title}
       </Fonts.body3>
@@ -106,12 +109,17 @@ const BigTag = ({ title, check, onClick }: TagProps) => {
 
 const SmallTag = ({ title, check, onClick }: TagProps) => {
   return (
-    <Tag onClick={onClick} bordercolor={check ? colors.gray03 : colors.gray06}>
+    <Tag onClick={onClick} bordercolor={check ? colors.gray01 : colors.gray05}>
       {check && <CheckBlack style={{ marginBottom: 2 }} />}
       <Fonts.body3
         color={colors.gray01}
         weight={500}
         margin={check ? '0 0 0 4px' : '0'}
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
       >
         {title}
       </Fonts.body3>
@@ -121,14 +129,17 @@ const SmallTag = ({ title, check, onClick }: TagProps) => {
 
 const Tag = styled.button<{ backgroundcolor?: string; bordercolor?: string }>`
   display: flex;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
-  min-width: 66px;
+  width: 'auto';
+  max-width: 150px;
   height: 30px;
   border: 1px solid ${(props) => props.bordercolor || colors.primary};
   border-radius: 100px;
   background-color: ${(props) => props.backgroundcolor || colors.white};
   margin: 0 5px 0 0;
+  padding: 0 10px 0 10px;
   cursor: pointer;
 `;
 
@@ -146,15 +157,41 @@ const BigBox = styled.div`
   box-sizing: border-box;
   border-top: 1px solid ${colors.gray03};
   background-color: ${colors.gray08};
+  overflow-x: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  -ms-overflow-style: none; // for Internet Explorer, Edge
+  scrollbar-width: none; // for Firefox
 `;
 
 const SmallBox = styled.div`
-  height: 52px;
+  height: 60px;
   width: 100%;
   display: flex;
+  flex-direction: row;
   align-items: center;
   justify-content: flex-start;
   padding-left: 13px;
   box-sizing: border-box;
   border-top: 1px solid ${colors.gray06};
+  overflow-x: auto;
+
+  // chrome, safari, opera,
+  &::-webkit-scrollbar {
+    height: 9px;
+  }
+  &::-webkit-scrollbar-thumb {
+    width: 3%;
+    background: ${colors.gray04};
+    border-radius: 10px;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: ${colors.gray08};
+  }
+
+  // Firefox
+  scrollbar-color: ${colors.gray04} ${colors.gray08};
+  scrollbar-width: thin;
 `;

--- a/src/components/ReviewSortingList/KeywordSortBar.tsx
+++ b/src/components/ReviewSortingList/KeywordSortBar.tsx
@@ -148,12 +148,11 @@ const Box = styled.div`
 `;
 
 const BigBox = styled.div`
-  height: 52px;
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  padding-left: 13px;
+  padding: 10px 0 10px 13px;
   box-sizing: border-box;
   border-top: 1px solid ${colors.gray03};
   background-color: ${colors.gray08};
@@ -178,13 +177,12 @@ const BigBox = styled.div`
 `;
 
 const SmallBox = styled.div`
-  height: 60px;
   width: 100%;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
-  padding-left: 13px;
+  padding: 10px 0 10px 13px;
   box-sizing: border-box;
   border-top: 1px solid ${colors.gray06};
   overflow-x: auto;

--- a/src/components/ReviewSortingList/KeywordSortBar.tsx
+++ b/src/components/ReviewSortingList/KeywordSortBar.tsx
@@ -158,12 +158,23 @@ const BigBox = styled.div`
   border-top: 1px solid ${colors.gray03};
   background-color: ${colors.gray08};
   overflow-x: auto;
+
+  // chrome, safari, opera, Edge
   &::-webkit-scrollbar {
-    display: none;
+    height: 9px;
+  }
+  &::-webkit-scrollbar-thumb {
+    width: 3%;
+    background: ${colors.gray04};
+    border-radius: 10px;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: ${colors.gray08};
   }
 
-  -ms-overflow-style: none; // for Internet Explorer, Edge
-  scrollbar-width: none; // for Firefox
+  // Firefox
+  scrollbar-color: ${colors.gray04} ${colors.gray08};
+  scrollbar-width: thin;
 `;
 
 const SmallBox = styled.div`
@@ -178,7 +189,7 @@ const SmallBox = styled.div`
   border-top: 1px solid ${colors.gray06};
   overflow-x: auto;
 
-  // chrome, safari, opera,
+  // chrome, safari, opera, Edge
   &::-webkit-scrollbar {
     height: 9px;
   }

--- a/src/components/ReviewStats/RatingStatBox.tsx
+++ b/src/components/ReviewStats/RatingStatBox.tsx
@@ -42,7 +42,7 @@ export default function RatingStatBox({ rating }: Props) {
                 ? starGreen
                 : star > rating + 1
                 ? starEmpty
-                : starIcons[Math.round((rating % 1) * 10)]
+                : starIcons[Math.round((rating * 10) % 10)]
             }
             width={20}
             alt="별점"

--- a/src/components/ReviewStats/index.tsx
+++ b/src/components/ReviewStats/index.tsx
@@ -22,7 +22,9 @@ export default function ReviewStats({
     <Box>
       <StatItem>
         {/* 점수에 따라 별점 채워짐(0.1 단위) */}
-        {reviewStats && <RatingStatBox rating={reviewStats?.averageRating} />}
+        {reviewStats && (
+          <RatingStatBox rating={reviewStats?.averageRating.toFixed(1)} />
+        )}
         <Margin margin={'5px 0 0 0'} />
         {reviewStats && (
           <Fonts.num2>{reviewStats?.averageRating.toFixed(1)}</Fonts.num2>


### PR DESCRIPTION
### 관련 이슈
#63 

### 작업 사항
- 별점 사진 안나타나는 버그 해결
- 태그 글자 수 넘치는 문제 해결, 스크롤바 커스텀

### 첨부
> FireFox
> <img width="1108" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/96554030-67c5-43b2-a1f8-12db3901a69a">

> Chrome, Edge
> <img width="1068" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/9d368b1f-8394-47b3-827e-d81407cd22b9">


### 특이사항
> FireFox의 스크롤바가 위아래로 좀 더 잘 눌리기 때문에 스크롤바를 더 얇게 만들었습니다. chrome, edge도 미관상 스크롤바를 얇게 하고 싶었으나, 사용성 문제로 좀 더 두껍게 했습니다.
