### PR TITLE
design :  키워드 나열 디자인 세로 스크롤로 변경

### DIFF
--- a/src/components/ReviewSortingList/KeywordSortBar.tsx
+++ b/src/components/ReviewSortingList/KeywordSortBar.tsx
@@ -8,12 +8,14 @@ import { useTags } from '@/reactQueryHooks/useTags';
 import ProductIdContext from '../contexts/ProductIdContext';
 import ProductTagContext from '../contexts/ProductTagContext';
 import { reviewTagMatch } from '@/utils/tagMatch';
+import { useQueryClient } from 'react-query';
 
 interface Props {
   setSelectedPage: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function KeywordSortBar({ setSelectedPage }: Props) {
+  const queryClient = useQueryClient();
   const { selectedTag, setSelectedTag, selectedBigTag, setSelectedBigTag } =
     useContext(ProductTagContext);
 
@@ -29,26 +31,39 @@ export default function KeywordSortBar({ setSelectedPage }: Props) {
 
   if (isLoading || isError) return <></>;
 
+  const onBigTagClick = (bigTag: string) => {
+    setSelectedTag('');
+    if (selectedBigTag === bigTag) {
+      setSelectedBigTag('');
+      setSelectedTag('');
+      return;
+    }
+    setSelectedBigTag(bigTag);
+  };
+
+  const onSmallTagClick = (smallTag: string) => {
+    if (selectedTag === smallTag) {
+      setSelectedTag('');
+      return;
+    }
+    setSelectedPage(1);
+    setSelectedTag(smallTag);
+  };
+
   return (
     <Box>
       <BigBox>
         {tagsData &&
-          Object.keys(tagsData)?.map((tagName, index) => {
-            const tag = reviewTagMatch[tagName];
+          Object.keys(tagsData)?.map((bigTag, index) => {
+            const tag = reviewTagMatch[bigTag];
             if (tag === undefined) return;
             return (
               <BigTag
                 key={index}
                 title={tag}
-                check={selectedBigTag === tagName}
+                check={selectedBigTag === bigTag}
                 onClick={() => {
-                  setSelectedTag('');
-                  if (selectedBigTag === tagName) {
-                    setSelectedBigTag('');
-                    setSelectedTag('');
-                    return;
-                  }
-                  setSelectedBigTag(tagName);
+                  onBigTagClick(bigTag);
                 }}
               />
             );
@@ -63,12 +78,7 @@ export default function KeywordSortBar({ setSelectedPage }: Props) {
                 title={smallTag}
                 check={selectedTag === smallTag}
                 onClick={() => {
-                  if (selectedTag === smallTag) {
-                    setSelectedTag('');
-                    return;
-                  }
-                  setSelectedPage(1);
-                  setSelectedTag(smallTag);
+                  onSmallTagClick(smallTag);
                 }}
               />
             ))}
@@ -138,7 +148,7 @@ const Tag = styled.button<{ backgroundcolor?: string; bordercolor?: string }>`
   border: 1px solid ${(props) => props.bordercolor || colors.primary};
   border-radius: 100px;
   background-color: ${(props) => props.backgroundcolor || colors.white};
-  margin: 0 5px 0 0;
+  margin: 2px 5px 2px 0;
   padding: 0 10px 0 10px;
   cursor: pointer;
 `;
@@ -178,21 +188,23 @@ const BigBox = styled.div`
 
 const SmallBox = styled.div`
   width: 100%;
+  max-height: 115px;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
   padding: 10px 0 10px 13px;
   box-sizing: border-box;
   border-top: 1px solid ${colors.gray06};
-  overflow-x: auto;
+  overflow-y: auto;
 
   // chrome, safari, opera, Edge
   &::-webkit-scrollbar {
-    height: 9px;
+    width: 9px;
   }
   &::-webkit-scrollbar-thumb {
-    width: 3%;
+    height: 30%;
     background: ${colors.gray04};
     border-radius: 10px;
   }

--- a/src/reactQueryHooks/useReviewAssistant.tsx
+++ b/src/reactQueryHooks/useReviewAssistant.tsx
@@ -26,13 +26,17 @@ export const useReviewRecommendations = ({
 }: ReviewRecommendations) => {
   return useMutation(getReviewRecommendations, {
     onSuccess: onSuccess,
-    onError: () => console.log('리뷰 추천에 실패했습니다.'),
+    onError: (err) => {
+      throw err;
+    },
   });
 };
 
 export const useReviewComplete = ({ onSuccess }: ReviewRecommendations) => {
   return useMutation(getReviewComplete, {
     onSuccess: onSuccess,
-    onError: () => console.log('리뷰완성에 실패했습니다.'),
+    onError: (err) => {
+      throw err;
+    },
   });
 };

--- a/src/reactQueryHooks/useStats.tsx
+++ b/src/reactQueryHooks/useStats.tsx
@@ -43,11 +43,8 @@ export const useReviewStats = ({
         singleTravelProductPartnerCustomId,
       }),
     {
-      onSuccess: (data) => {
-        console.log('태그 통계 불러오기 성공', data);
-      },
       onError: (error) => {
-        console.log('태그 통계 불러오기 실패', error);
+        throw error;
       },
     }
   );
@@ -66,11 +63,8 @@ export const useTagStats = ({
         singleTravelProductPartnerCustomId,
       }),
     {
-      onSuccess: () => {
-        console.log('태그 통계 불러오기 성공');
-      },
       onError: (error) => {
-        console.log('태그 통계 불러오기 실패', error);
+        throw error;
       },
     }
   );

--- a/src/reactQueryHooks/useTags.tsx
+++ b/src/reactQueryHooks/useTags.tsx
@@ -22,11 +22,8 @@ export const useTags = ({
     ['tags', partnerDomain, singleTravelProductPartnerCustomId],
     () => fetchTags({ partnerDomain, singleTravelProductPartnerCustomId }),
     {
-      onSuccess: () => {
-        console.log('태그 불러오기 성공');
-      },
-      onError: () => {
-        console.log('태그 불러오기 실패');
+      onError: (err) => {
+        throw err;
       },
     }
   );


### PR DESCRIPTION
### 관련 이슈

### 작업 사항
- 기존 키워드 가로 스크롤이 불편하뎌 세로 스크롤로 변경

### 첨부
> 기존
> <img width="1103" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/2dbb7ab6-4ab3-4678-84b3-904b7f52756c">


> 변경
> <img width="1107" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/61eebeec-ebcc-4a08-b313-a3c63ab14026">


### 특이사항
> 최대 3줄의 태그까지 볼 수 있음