### PR TITLE
[빌드27] fix,feat: 리뷰 자동 완성 시 인덱스 오류 수정, 리뷰 클릭 시 사라지는 기능 추가

### DIFF
--- a/src/components/ReviewAssistant/Comment.tsx
+++ b/src/components/ReviewAssistant/Comment.tsx
@@ -11,21 +11,27 @@ import styled, { keyframes } from 'styled-components';
 import { ReactComponent as AIBot } from '@/assets/icons/aibot.svg';
 
 interface CommentProps {
+  visible: boolean;
   sort: ReviewAssistType;
   polarity?: ReviewPolarityType;
   idx?: number[];
   reviewInput: string;
   setReviewInput: Dispatch<SetStateAction<string>>;
   newReviewInput: string;
+  changeCommentIdx: (sort: number, newIdx: number[]) => void;
+  removeComments: (sort: number) => void;
 }
 
 export const Comment = ({
+  visible,
   sort,
   polarity,
   idx,
   reviewInput,
   setReviewInput,
   newReviewInput,
+  changeCommentIdx,
+  removeComments,
 }: CommentProps) => {
   let title;
   if (sort == ReviewAssist.RECOMMEND) title = '주제 추천';
@@ -42,7 +48,12 @@ export const Comment = ({
 
     let newText = reviewInput.substring(0, idx1);
     newText += newReviewInput;
-    newText += reviewInput.substring(idx2);
+    if (idx2 !== -1) newText += reviewInput.substring(idx2);
+
+    // 변경된 idx 적용
+    changeCommentIdx(sort, [idx1, idx2]);
+
+    removeComments(sort);
 
     setReviewInput(newText);
   };
@@ -51,6 +62,7 @@ export const Comment = ({
     <CommentBox
       sort={sort}
       polarity={polarity}
+      visible={visible}
       onClick={sort == ReviewAssist.COMPLETE ? sentenceComplete : undefined}
     >
       <Row margin="0 0 6px 0">
@@ -79,9 +91,19 @@ const BoxFadeIn = keyframes`
   }
 `;
 
+const BoxFadeOut = keyframes`
+  0% {
+    opacity: 100;
+  }
+  100% {
+    opacity: 0;
+  }
+`;
+
 const CommentBox = styled.button<{
   sort: ReviewAssistType;
   polarity: ReviewPolarityType;
+  visible?: boolean;
 }>`
   display: flex;
   flex-direction: column;
@@ -103,6 +125,7 @@ const CommentBox = styled.button<{
       : props.polarity
       ? colors.lightRed
       : colors.lightBlue};
-  animation: ${BoxFadeIn} 0.7s forwards ease-out;
+  animation: ${(props) => (props.visible ? BoxFadeIn : BoxFadeOut)}
+    ${(props) => (props.visible ? '0.7s' : '0.4s')} forwards ease-out;
   cursor: ${(props) => (props.sort == 1 ? 'default' : 'pointer')};
 `;

--- a/src/components/ReviewAssistant/Comment.tsx
+++ b/src/components/ReviewAssistant/Comment.tsx
@@ -11,7 +11,6 @@ import styled, { keyframes } from 'styled-components';
 import { ReactComponent as AIBot } from '@/assets/icons/aibot.svg';
 
 interface CommentProps {
-  visible: boolean;
   sort: ReviewAssistType;
   polarity?: ReviewPolarityType;
   idx?: number[];
@@ -19,11 +18,9 @@ interface CommentProps {
   setReviewInput: Dispatch<SetStateAction<string>>;
   newReviewInput: string;
   changeCommentIdx: (sort: number, newIdx: number[]) => void;
-  removeComments: (sort: number) => void;
 }
 
 export const Comment = ({
-  visible,
   sort,
   polarity,
   idx,
@@ -31,7 +28,6 @@ export const Comment = ({
   setReviewInput,
   newReviewInput,
   changeCommentIdx,
-  removeComments,
 }: CommentProps) => {
   let title;
   if (sort == ReviewAssist.RECOMMEND) title = '주제 추천';
@@ -42,9 +38,8 @@ export const Comment = ({
 
     const idx1 = idx[0];
     let idx2 = idx[1];
-    if (idx2 > reviewInput.length || idx2 == -1)
-      idx2 = idx1 + newReviewInput.length;
-    if (idx2 < idx1 || idx1 < 0) return;
+    if ((idx2 !== -1 && idx2 < idx1) || idx1 < 0) return;
+    if (idx2 > idx1 + reviewInput.length) idx2 = idx1 + newReviewInput.length;
 
     let newText = reviewInput.substring(0, idx1);
     newText += newReviewInput;
@@ -53,8 +48,6 @@ export const Comment = ({
     // 변경된 idx 적용
     changeCommentIdx(sort, [idx1, idx2]);
 
-    removeComments(sort);
-
     setReviewInput(newText);
   };
 
@@ -62,7 +55,6 @@ export const Comment = ({
     <CommentBox
       sort={sort}
       polarity={polarity}
-      visible={visible}
       onClick={sort == ReviewAssist.COMPLETE ? sentenceComplete : undefined}
     >
       <Row margin="0 0 6px 0">
@@ -91,19 +83,9 @@ const BoxFadeIn = keyframes`
   }
 `;
 
-const BoxFadeOut = keyframes`
-  0% {
-    opacity: 100;
-  }
-  100% {
-    opacity: 0;
-  }
-`;
-
 const CommentBox = styled.button<{
   sort: ReviewAssistType;
   polarity: ReviewPolarityType;
-  visible?: boolean;
 }>`
   display: flex;
   flex-direction: column;
@@ -125,7 +107,6 @@ const CommentBox = styled.button<{
       : props.polarity
       ? colors.lightRed
       : colors.lightBlue};
-  animation: ${(props) => (props.visible ? BoxFadeIn : BoxFadeOut)}
-    ${(props) => (props.visible ? '0.7s' : '0.4s')} forwards ease-out;
+  animation: ${BoxFadeIn} 0.7s forwards ease-out;
   cursor: ${(props) => (props.sort == 1 ? 'default' : 'pointer')};
 `;

--- a/src/components/ReviewAssistant/index.tsx
+++ b/src/components/ReviewAssistant/index.tsx
@@ -8,15 +8,50 @@ import { CommentType } from '@/types/Comments';
 
 interface Props {
   comments: CommentType[];
+  setComments: React.Dispatch<React.SetStateAction<CommentType[]>>;
   reviewInput: string;
   setReviewInput: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export default function ReviewAssistant({
   comments,
+  setComments,
   reviewInput,
   setReviewInput,
 }: Props) {
+  const changeCommentIdx = (sort: number, newIdx: number[]) => {
+    setComments(
+      comments.map((comment) => {
+        if (comment.sort == sort) {
+          return {
+            ...comment,
+            idx: newIdx,
+          };
+        }
+        return comment;
+      })
+    );
+  };
+  const removeComments = (sort: number) => {
+    setComments((comments) => {
+      return comments.map((comment) => {
+        if (comment.sort == sort) {
+          return {
+            ...comment,
+            visible: false,
+          };
+        }
+        return comment;
+      });
+    });
+    setTimeout(() => {
+      setComments(
+        comments.filter((comment) => {
+          return comment.sort != sort;
+        })
+      );
+    }, 400);
+  };
   return (
     <Container>
       <AIBox>
@@ -29,12 +64,15 @@ export default function ReviewAssistant({
         return (
           <Comment
             key={index}
+            visible={comment.visible}
             sort={comment.sort}
-            idx={comment?.idx}
+            idx={comment.idx}
             polarity={comment?.polarity}
             newReviewInput={comment.content}
             reviewInput={reviewInput}
             setReviewInput={setReviewInput}
+            changeCommentIdx={changeCommentIdx}
+            removeComments={removeComments}
           />
         );
       })}

--- a/src/components/ReviewAssistant/index.tsx
+++ b/src/components/ReviewAssistant/index.tsx
@@ -32,26 +32,7 @@ export default function ReviewAssistant({
       })
     );
   };
-  const removeComments = (sort: number) => {
-    setComments((comments) => {
-      return comments.map((comment) => {
-        if (comment.sort == sort) {
-          return {
-            ...comment,
-            visible: false,
-          };
-        }
-        return comment;
-      });
-    });
-    setTimeout(() => {
-      setComments(
-        comments.filter((comment) => {
-          return comment.sort != sort;
-        })
-      );
-    }, 400);
-  };
+
   return (
     <Container>
       <AIBox>
@@ -64,7 +45,6 @@ export default function ReviewAssistant({
         return (
           <Comment
             key={index}
-            visible={comment.visible}
             sort={comment.sort}
             idx={comment.idx}
             polarity={comment?.polarity}
@@ -72,7 +52,6 @@ export default function ReviewAssistant({
             reviewInput={reviewInput}
             setReviewInput={setReviewInput}
             changeCommentIdx={changeCommentIdx}
-            removeComments={removeComments}
           />
         );
       })}

--- a/src/components/ReviewSortingList/KeywordSortBar.tsx
+++ b/src/components/ReviewSortingList/KeywordSortBar.tsx
@@ -15,7 +15,6 @@ interface Props {
 }
 
 export default function KeywordSortBar({ setSelectedPage }: Props) {
-  const queryClient = useQueryClient();
   const { selectedTag, setSelectedTag, selectedBigTag, setSelectedBigTag } =
     useContext(ProductTagContext);
 

--- a/src/hooks/useReviewAndComments.tsx
+++ b/src/hooks/useReviewAndComments.tsx
@@ -3,7 +3,7 @@ import { ChangeEvent, useState } from 'react';
 import { useReviewRecommendations } from '../reactQueryHooks/useReviewAssistant';
 import { CommentType } from '@/types/Comments';
 
-// 정의 : 리뷰 작성 중인 내용과 마지막으로 추천받은 인덱스를 관리하는 커스텀 훅
+// 리뷰 작성 중인 내용을 관리하는 커스텀 훅
 export const useReviewAndComments = () => {
   const [reviewInput, setReviewInput] = useState(''); // 리뷰 작성 중인 내용
   const [comments, setComments] = useState<CommentType[]>([]); // 리뷰 보조 AI가 추천한 문장 리스트
@@ -11,9 +11,18 @@ export const useReviewAndComments = () => {
   // 리뷰 작성 중인 내용에 대한 추천 문장 요청
   const { mutate: reviewRecommendMutate } = useReviewRecommendations({
     onSuccess: (data) => {
-      data?.body?.forEach((comment) => {
-        setComments((prevComments) => [...prevComments, comment]);
-      });
+      console.log(data?.body[0]?.sort);
+
+      setComments(
+        comments.filter((comment) => comment.sort !== data?.body[0]?.sort)
+      );
+      // 나타나는 에니메이션 효과를 위해 0.1초 뒤에 데이터 추가
+      setTimeout(() => {
+        data?.body?.forEach((comment) => {
+          const newComment = { ...comment, visible: true }; // 에니메이션 효과 위해 visible 변수 추가
+          setComments((prevComments) => [...prevComments, newComment]);
+        });
+      }, 100);
     },
   });
 

--- a/src/pages/ReviewWrite.tsx
+++ b/src/pages/ReviewWrite.tsx
@@ -11,8 +11,13 @@ export default function ReviewWrite() {
 
   const [title, setTitle] = useState<string>('');
 
-  const { reviewInput, setReviewInput, comments, handleInputChange } =
-    useReviewAndComments();
+  const {
+    reviewInput,
+    setReviewInput,
+    comments,
+    setComments,
+    handleInputChange,
+  } = useReviewAndComments();
 
   return (
     <Container ref={componentRef}>
@@ -26,6 +31,7 @@ export default function ReviewWrite() {
       <Margin margin={'0 0 0 20px'} />
       <ReviewAssistant
         comments={comments}
+        setComments={setComments}
         reviewInput={reviewInput}
         setReviewInput={setReviewInput}
       />

--- a/src/types/Comments.tsx
+++ b/src/types/Comments.tsx
@@ -5,4 +5,5 @@ export interface CommentType {
   content: string;
   idx?: number[];
   polarity?: ReviewPolarity;
+  visible: boolean;
 }

--- a/src/types/Comments.tsx
+++ b/src/types/Comments.tsx
@@ -5,5 +5,4 @@ export interface CommentType {
   content: string;
   idx?: number[];
   polarity?: ReviewPolarity;
-  visible: boolean;
 }


### PR DESCRIPTION
### 관련 이슈
#58

### 작업 사항
- 더 긴 리뷰문장을 클릭 후, 짧은 리뷰 문장 클릭시 교체되는 범위가 바뀌지 않아서 기존 리뷰 문장이 뒷부분에 남아있는 버그 발생
- 리뷰 문장 클릭시 인덱스 업데이트 하는 로직 추가로 해결

### 첨부
https://github.com/review-mate/review-mate-insert-module/assets/65444249/c7fecbb2-0019-47ea-a22d-09ce4f8fc321


