### PR TITLE
[빌드28] feat: 리뷰 별점 통계 그래프의 max 기준 변경

### DIFF
--- a/public/script/widgetScript.js
+++ b/public/script/widgetScript.js
@@ -9,6 +9,7 @@ const createIframe = ($widgetContainer, type) => {
   iframe.style.width = '100%';
   iframe.style.height = '0';
   iframe.style.border = 'none';
+  iframe.style.overflow = 'hidden';
   iframe.scrolling = 'no';
 
   return iframe;

--- a/src/components/ReviewStats/index.tsx
+++ b/src/components/ReviewStats/index.tsx
@@ -2,7 +2,7 @@ import StatBars from '@/components/ReviewStats/StatBars';
 import { Margin } from '@/ui/margin/margin';
 import { Fonts } from '@/utils/GlobalFonts';
 import { colors } from '@/utils/GlobalStyles';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { styled } from 'styled-components';
 import RatingStatBox from './RatingStatBox';
 import LoadingBar from '@/ui/loadingBar/LoadingBar';
@@ -18,6 +18,18 @@ export default function ReviewStats({
   isLoading,
   isError,
 }: Props) {
+  const getMaxPropertyCount = () => {
+    return Math.max(
+      reviewStats?.oneStarRatingCount,
+      reviewStats?.twoStarRatingCount,
+      reviewStats?.threeStarRatingCount,
+      reviewStats?.fourStarRatingCount,
+      reviewStats?.fiveStarRatingCount
+    );
+  };
+
+  const maxCount = useMemo(() => getMaxPropertyCount(), [reviewStats]);
+
   return (
     <Box>
       <StatItem>
@@ -42,7 +54,7 @@ export default function ReviewStats({
         )}
       </StatItem>
       <StatItem>
-        {/* 전체 리뷰 수를 100으로, 퍼센트(%)만큼 채워짐 */}
+        {/* 가장 많은 별점 수를 기준으로, 퍼센트(%)만큼 채워짐 */}
         {reviewStats && (
           <StatBars
             scoreList={[
@@ -52,7 +64,7 @@ export default function ReviewStats({
               reviewStats?.twoStarRatingCount,
               reviewStats?.oneStarRatingCount,
             ]}
-            max={reviewStats?.reviewCount}
+            max={maxCount}
           />
         )}
       </StatItem>


### PR DESCRIPTION
### 관련 이슈

### 작업 사항
- 리뷰 별점 통계 그래프의 max 기준 변경  
- -> 무조건 한개는 max가 되도록해서 통계가 눈에 더 잘 띄도록 함

### 첨부
> 기존
> <img width="220" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/bd0627d2-cf30-48be-b9ac-5a9cdeedfaf7">
> 변결
> <img width="260" alt="image" src="https://github.com/review-mate/review-mate-insert-module/assets/65444249/b3706ffa-0249-4be4-83d1-0d572ed2881f">

